### PR TITLE
Support storage zones for fetching run outputs [WIP]

### DIFF
--- a/airplane/exceptions.py
+++ b/airplane/exceptions.py
@@ -95,3 +95,6 @@ class UnsupportedDefaultTypeException(Exception):
 
 class InvalidTaskConfigurationException(Exception):
     """Exception that indicates an inline task configuration is invalid."""
+
+class InvalidZoneException(Exception):
+    """Exception indicating that a run storage zone info is invalid."""

--- a/airplane/runtime/standard.py
+++ b/airplane/runtime/standard.py
@@ -85,7 +85,8 @@ def execute(
             raise ValueError("Unable to find run ID for completed request")
 
     run_info = __wait_for_run_completion(run_id)
-    outputs = client.get_run_output(run_id)
+    use_zone = run_info.get('zoneID', None) is not None
+    outputs = client.get_run_output(run_id, use_zone=use_zone)
     # pylint: disable=redefined-outer-name
     run = Run(
         id=run_info["id"],
@@ -129,7 +130,8 @@ def run(
     client = api_client_from_env()
     run_id = client.create_run(task_id, parameters, env, constraints)
     run_info = __wait_for_run_completion(run_id)
-    outputs = client.get_run_output(run_id)
+    use_zone = run_info.get('zoneID', None) is not None
+    outputs = client.get_run_output(run_id, use_zone=use_zone)
     return {"status": run_info["status"], "outputs": outputs}
 
 


### PR DESCRIPTION
## Description
This change updates the python SDK to support fetching outputs from runs that are using storage zones. See https://github.com/airplanedev/js-sdk/pull/320 for the equivalent changes in the js sdk.

## Testing
TBD