### PR TITLE
Add convertToDef function to convert python config to task def

### DIFF
--- a/airplane/config.py
+++ b/airplane/config.py
@@ -223,7 +223,7 @@ def task(
     def decorator(func: Callable[P, Any]) -> Callable[P, Run]:
         """Assigns an __airplane attribute to a function to mark it as an Airplane object"""
 
-        config = TaskDef.build(
+        config = Config.build(
             func=func,
             runtime="",
             slug=slug,
@@ -280,7 +280,7 @@ class ParamDef:
 
 
 @dataclasses.dataclass(frozen=True)
-class TaskDef:
+class Config:
     """Task definition"""
 
     func: Callable[..., Any]
@@ -358,7 +358,7 @@ class TaskDef:
         resources: Optional[List[Resource]],
         schedules: Optional[List[Schedule]],
         env_vars: Optional[List[EnvVar]],
-    ) -> "TaskDef":
+    ) -> "Config":
         """Construct a task definition from a function."""
         task_description = description
         if func.__doc__ is None:

--- a/tests/airplane/test_config.py
+++ b/tests/airplane/test_config.py
@@ -8,13 +8,13 @@ from typing_extensions import Annotated
 from airplane._version import __version__
 from airplane.api.entities import Run, RunStatus
 from airplane.config import (
+    Config,
     EnvVar,
     LabeledOption,
     ParamConfig,
     ParamDef,
     Resource,
     Schedule,
-    TaskDef,
     task,
 )
 from airplane.exceptions import (
@@ -33,7 +33,7 @@ def test_definition_with_defaults() -> None:
     def my_task(param: str) -> str:
         return param
 
-    assert my_task.__airplane == TaskDef(  # type: ignore
+    assert my_task.__airplane == Config(  # type: ignore
         func=my_task.__wrapped__,  # type: ignore
         runtime="",
         slug="my_task",
@@ -167,7 +167,7 @@ def test_decorator_with_parameters() -> None:
     def my_task() -> None:
         pass
 
-    assert my_task.__airplane == TaskDef(  # type: ignore
+    assert my_task.__airplane == Config(  # type: ignore
         func=my_task.__wrapped__,  # type: ignore
         runtime="",
         slug="task_slug",
@@ -241,7 +241,7 @@ def test_param_configs() -> None:
             annotated_default,
         )
 
-    assert my_task.__airplane == TaskDef(  # type: ignore
+    assert my_task.__airplane == Config(  # type: ignore
         func=my_task.__wrapped__,  # type: ignore
         runtime="",
         slug="my_task",
@@ -887,7 +887,7 @@ def test_definition_nested_types() -> None:
         del param_optional, param_optional_nested
         return param
 
-    assert my_task.__airplane == TaskDef(  # type: ignore
+    assert my_task.__airplane == Config(  # type: ignore
         func=my_task.__wrapped__,  # type: ignore
         runtime="",
         slug="my_task",
@@ -952,7 +952,7 @@ def test_param_config_default() -> None:
         del foo, bar
         return foo
 
-    assert my_task.__airplane == TaskDef(  # type: ignore
+    assert my_task.__airplane == Config(  # type: ignore
         func=my_task.__wrapped__,  # type: ignore
         runtime="",
         slug="my_task",


### PR DESCRIPTION
Resolves CAP-2582

Adds a function to the task object to convert its config to a task definition that lib understands. This will allow us to make changes in the python-sdk that are automatically versioned/compatible with any version of lib.